### PR TITLE
Remove debug alert from AppProvider

### DIFF
--- a/src/context/app/app-provider.jsx
+++ b/src/context/app/app-provider.jsx
@@ -12,8 +12,6 @@ export const AppProvider = ({ children }) => {
   const urlApi = import.meta.env.VITE_API_URL;
   const apiKey = import.meta.env.VITE_API_TK;
 
-  alert("Api URL: " + urlApi);
-
   const [theme, setTheme] = useState("light");
   const [language, setLanguage] = useState("es");
 


### PR DESCRIPTION
Eliminated an alert displaying the API URL from the AppProvider component. This cleans up unnecessary debug output in the application.