### PR TITLE
Add comment for environment variables in AppProvider

### DIFF
--- a/src/context/app/app-provider.jsx
+++ b/src/context/app/app-provider.jsx
@@ -8,7 +8,7 @@ export const AppProvider = ({ children }) => {
   AppProvider.propTypes = {
     children: PropTypes.node.isRequired,
   };
-
+  // Variables de entorno
   const urlApi = import.meta.env.VITE_API_URL;
   const apiKey = import.meta.env.VITE_API_TK;
 


### PR DESCRIPTION
Added a comment to clarify the purpose of environment variable assignments for API URL and API key in the AppProvider component.