### PR TITLE
Update API key environment variable name

### DIFF
--- a/src/components/login/login.jsx
+++ b/src/components/login/login.jsx
@@ -30,7 +30,7 @@ export default function Login() {
       {
         headers: {
           "Content-Type": "application/json",
-          "api-key": import.meta.env.VITE_API_TK,
+          "api-key": import.meta.env.VITE_API_KEY,
         },
       }
     );

--- a/src/context/app/app-provider.jsx
+++ b/src/context/app/app-provider.jsx
@@ -10,7 +10,7 @@ export const AppProvider = ({ children }) => {
   };
   // Variables de entorno
   const urlApi = import.meta.env.VITE_API_URL;
-  const apiKey = import.meta.env.VITE_API_TK;
+  const apiKey = import.meta.env.VITE_API_KEY;
 
   const [theme, setTheme] = useState("light");
   const [language, setLanguage] = useState("es");


### PR DESCRIPTION
Replaces usage of VITE_API_TK with VITE_API_KEY in both the login component and app provider to standardize environment variable naming.