### PR TITLE
Fix typo in billing route name

### DIFF
--- a/src/routes/router/routes.jsx
+++ b/src/routes/router/routes.jsx
@@ -59,7 +59,7 @@ export const appRoutes = [
   {
     id: crypto.randomUUID(),
     path: "/billing",
-    name: "Facturacion",
+    name: "Facturación",
     element: Billing,
     icon: <BillingIcon />,
   },


### PR DESCRIPTION
Corrected the spelling of 'Facturacion' to 'Facturación' in the billing route for improved accuracy and localization.